### PR TITLE
fix: honor consumer_1_icon config in compact_view bars mode

### DIFF
--- a/dist/power-flux-card.js
+++ b/dist/power-flux-card.js
@@ -1978,7 +1978,7 @@ console.log(
         let iconColor = '';
 
         if (type === 'house') { icon = 'mdi:home'; iconColor = 'var(--icon-house-color)'; }
-        if (type === 'car') { icon = 'mdi:car-electric'; iconColor = 'var(--icon-consumer-1-color)'; }
+        if (type === 'car') { icon = this.config.consumer_1_icon || 'mdi:car-electric'; iconColor = 'var(--icon-consumer-1-color)'; }
         if (type === 'export') { icon = 'mdi:arrow-right-box'; iconColor = 'var(--export-color)'; }
         if (type === 'battery') { icon = 'mdi:battery-charging-high'; iconColor = 'var(--icon-battery-color)'; }
 
@@ -2094,7 +2094,7 @@ console.log(
                         </div>` : ''}
                         ${evPower > 0 ? html`
                         <div class="compact-detail-item" @click=${() => entities.consumer_1 && this._handleClick(entities.consumer_1)} style="cursor: ${entities.consumer_1 ? 'pointer' : 'default'};">
-                            <ha-icon icon="mdi:car-electric" style="color: var(--icon-consumer-1-color);"></ha-icon>
+                            <ha-icon icon="${this.config.consumer_1_icon || 'mdi:car-electric'}" style="color: var(--icon-consumer-1-color);"></ha-icon>
                             <span class="compact-detail-label">${this.config.consumer_1_label || 'EV'}</span>
                             <span class="compact-detail-value" style="color: var(--consumer-1-color);">${this._formatPower(evPower)}</span>
                         </div>` : ''}

--- a/src/power-flux-card.js
+++ b/src/power-flux-card.js
@@ -790,7 +790,7 @@ console.log(
         let iconColor = '';
 
         if (type === 'house') { icon = 'mdi:home'; iconColor = 'var(--icon-house-color)'; }
-        if (type === 'car') { icon = 'mdi:car-electric'; iconColor = 'var(--icon-consumer-1-color)'; }
+        if (type === 'car') { icon = this.config.consumer_1_icon || 'mdi:car-electric'; iconColor = 'var(--icon-consumer-1-color)'; }
         if (type === 'export') { icon = 'mdi:arrow-right-box'; iconColor = 'var(--export-color)'; }
         if (type === 'battery') { icon = 'mdi:battery-charging-high'; iconColor = 'var(--icon-battery-color)'; }
 
@@ -906,7 +906,7 @@ console.log(
                         </div>` : ''}
                         ${evPower > 0 ? html`
                         <div class="compact-detail-item" @click=${() => entities.consumer_1 && this._handleClick(entities.consumer_1)} style="cursor: ${entities.consumer_1 ? 'pointer' : 'default'};">
-                            <ha-icon icon="mdi:car-electric" style="color: var(--icon-consumer-1-color);"></ha-icon>
+                            <ha-icon icon="${this.config.consumer_1_icon || 'mdi:car-electric'}" style="color: var(--icon-consumer-1-color);"></ha-icon>
                             <span class="compact-detail-label">${this.config.consumer_1_label || 'EV'}</span>
                             <span class="compact-detail-value" style="color: var(--consumer-1-color);">${this._formatPower(evPower)}</span>
                         </div>` : ''}


### PR DESCRIPTION
## Summary

The `consumer_1_icon` config option was only used in standard/circle view. The `compact_view` (bars mode) hardcoded `mdi:car-electric` in two places, ignoring user config:

1. The consumer_1 bracket icon in `addBottomBracket` (within `_renderCompactView`)
2. The consumer_1 detail row icon rendered below the bars

This PR makes both paths honor `this.config.consumer_1_icon`, falling back to `mdi:car-electric` when not set — so existing users see no change.

## Changes

- `src/power-flux-card.js`:
  - Line ~793: `if (type === 'car') { icon = this.config.consumer_1_icon || 'mdi:car-electric'; ... }`
  - Line ~909: `<ha-icon icon="\${this.config.consumer_1_icon || 'mdi:car-electric'}" ...>`
- `dist/power-flux-card.js`: rebuilt via `node build.js`

## Test plan

- [x] Rebuild via `node build.js` succeeds
- [x] Default behavior unchanged when `consumer_1_icon` not set (still shows car icon)
- [x] Setting `consumer_1_icon: mdi:hot-tub` in a compact_view config renders the custom icon in both the bracket and the detail row

